### PR TITLE
Call pre_send_fun again in case send after reconnect

### DIFF
--- a/src/nkpacket_transport.erl
+++ b/src/nkpacket_transport.erl
@@ -215,8 +215,12 @@ do_send(_Msg, [], Opts) ->
 
 do_send(Msg, [Port|Rest], #{pre_send_fun:=Fun}=Opts) ->
     Msg1 = get_msg_fun(Fun, Msg, Port),
-    do_send(Msg1, [Port|Rest], maps:remove(pre_send_fun, Opts));
-
+    case do_send(Msg1, [Port|Rest], maps:remove(pre_send_fun, Opts)) of
+        { ok, _ } = Result ->
+            Result;
+        { error, Opts1 } ->
+            { error, Opts1#{ pre_send_fun => Fun } }
+    end;
 do_send(Msg, [Port|Rest], Opts) ->
     SendOpts = case maps:find(udp_max_size, Opts) of
         {ok, MaxSize} -> #{udp_max_size=>MaxSize};


### PR DESCRIPTION
If error occured during send and re-connect is called  then  then result of initial pre_send_fun is ignored.
I've added pre_send_fun to result options to avoid this behaviour.

nksip use pre_send_fun for via fill so message after reconnect was not valid and also caused crash.