### PR TITLE
Fixed crashed connections being kept as still active

### DIFF
--- a/src/nkpacket_pool.erl
+++ b/src/nkpacket_pool.erl
@@ -385,7 +385,7 @@ handle_info({'DOWN', Mon, process, Pid, Reason}=Msg, State) ->
                     ?LLOG(notice, "exclusive user ~p down, stopping ~p",
                           [Pid, ConnId], State),
                     %% Connection may be in inconsistent state, stop it
-                    StopFun(Pid),
+                    StopFun(ConnPid),
                     State2 = State#state{conn_user_mons=Mons2},
                     {noreply, State2};
                 error ->


### PR DESCRIPTION
This caused the pool to be reduced every time that happened so, in the end, the pool stops accepting new connections