### PR TITLE
Introduce tos for connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ connect_timeout|`integer()`|30000|(msecs)
 sctp_out_streams|`integer()`|10|Default SCTP out streams
 sctp_in_streams|`integer()`|10|Default SCTP in streams
 tcp_listeners|`integer()`|10|Default number of TCP listeners
+tos|`integer()`|0|Default value for Type of Service
 main_ip|`inet:ip4_address()`|auto|Main IPv4 of the host
 main_ip6|`inet:ip6_address()`|auto|Main IPv6 of the host
 ext_ip|`inet:ip4_address()`|auto|Public Ipv4 of the host

--- a/include/nkpacket.hrl
+++ b/include/nkpacket.hrl
@@ -26,7 +26,7 @@
 %% ===================================================================
 
 -define(CONN_LISTEN_OPTS, 
-    [group, user, idle_timeout, host, path, ws_proto, refresh_fun, debug, external_url]).
+    [group, user, idle_timeout, host, path, ws_proto, refresh_fun, debug, external_url, tos]).
 
 -define(CONN_CLIENT_OPTS, [monitor|?CONN_LISTEN_OPTS]).
 

--- a/src/nkpacket.app.src
+++ b/src/nkpacket.app.src
@@ -5,6 +5,8 @@
     {registered, []},
     {mod, {nkpacket_app, []}},
     {applications, [
+        kernel,
+        stdlib,
         crypto,
         ssl,
         nklib,

--- a/src/nkpacket.erl
+++ b/src/nkpacket.erl
@@ -112,6 +112,7 @@
         tcp_listeners => integer(),             % Default 100
         send_timeout => integer(),
         send_timeout_close => boolean(),
+        tos => integer(),
 
         % WS/WSS/HTTP/HTTPS options
         host => string() | binary(),            % Listen only on this host
@@ -167,6 +168,7 @@
         tcp_packet => 1 | 2 | 4 | raw,    
         send_timeout => integer(),
         send_timeout_close => boolean(),
+        tos => integer(),
 
         % WS/WSS
         host => string() | binary(),        % Host header to use

--- a/src/nkpacket_config.erl
+++ b/src/nkpacket_config.erl
@@ -24,7 +24,7 @@
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 -export([set_config/0]).
 -export([max_connections/0, dns_cache_ttl/0, udp_timeout/0, tcp_timeout/0, sctp_timeout/0,
-         ws_timeout/0, http_timeout/0, connect_timeout/0, sctp_in_streams/0,
+         ws_timeout/0, http_timeout/0, connect_timeout/0, sctp_in_streams/0, tos/0,
          sctp_out_streams/0, main_ip/0, main_ip6/0, ext_ip/0, ext_ip6/0, local_ips/0]).
 
 
@@ -39,6 +39,7 @@
     connect_timeout :: integer(),
     sctp_in_streams :: integer(),
     sctp_out_streams :: integer(),
+    tos :: integer(),
     main_ip :: inet:ip4_address(),
     main_ip6 :: inet:ip6_address(),
     ext_ip :: inet:ip4_address(),
@@ -59,6 +60,7 @@ set_config() ->
         connect_timeout = nkpacket_app:get(connect_timeout),
         sctp_in_streams = nkpacket_app:get(sctp_in_streams),
         sctp_out_streams = nkpacket_app:get(sctp_out_streams),
+        tos = nkpacket_app:get(tos),
         main_ip = nkpacket_app:get(main_ip),
         main_ip6 = nkpacket_app:get(main_ip6),
         ext_ip = nkpacket_app:get(ext_ip),
@@ -79,6 +81,7 @@ http_timeout() -> do_get_config(#nkpacket_config.http_timeout).
 connect_timeout() -> do_get_config(#nkpacket_config.connect_timeout).
 sctp_in_streams() -> do_get_config(#nkpacket_config.sctp_in_streams).
 sctp_out_streams() -> do_get_config(#nkpacket_config.sctp_out_streams).
+tos() -> do_get_config(#nkpacket_config.tos).
 main_ip() -> do_get_config(#nkpacket_config.main_ip).
 main_ip6() -> do_get_config(#nkpacket_config.main_ip6).
 ext_ip() -> do_get_config(#nkpacket_config.ext_ip).

--- a/src/nkpacket_syntax.erl
+++ b/src/nkpacket_syntax.erl
@@ -46,7 +46,7 @@ app_syntax() ->
         connect_timeout => nat_integer,
         sctp_out_streams => nat_integer,
         sctp_in_streams => nat_integer,
-        tos => nat_integer,
+        tos => pos_integer,
         main_ip => [ip4, {atom, [auto]}],
         main_ip6 => [ip6, {atom, [auto]}],
         ext_ip => [ip4, {atom, [auto]}],
@@ -116,7 +116,7 @@ syntax() ->
         resolve_type => {atom, [listen, connect, send]},
         base_nkport => [boolean, {record, nkport}],
         user_state => any,
-        tos => nat_integer,
+        tos => pos_integer,
         debug => boolean
     },
     add_tls_syntax(Base).

--- a/src/nkpacket_syntax.erl
+++ b/src/nkpacket_syntax.erl
@@ -46,6 +46,7 @@ app_syntax() ->
         connect_timeout => nat_integer,
         sctp_out_streams => nat_integer,
         sctp_in_streams => nat_integer,
+        tos => nat_integer,
         main_ip => [ip4, {atom, [auto]}],
         main_ip6 => [ip6, {atom, [auto]}],
         ext_ip => [ip4, {atom, [auto]}],
@@ -61,6 +62,7 @@ app_syntax() ->
             connect_timeout => 30000,               %
             sctp_out_streams => 10,
             sctp_in_streams => 10,
+            tos => 0,
             main_ip => auto,
             main_ip6 => auto,
             ext_ip => auto,
@@ -114,6 +116,7 @@ syntax() ->
         resolve_type => {atom, [listen, connect, send]},
         base_nkport => [boolean, {record, nkport}],
         user_state => any,
+        tos => nat_integer,
         debug => boolean
     },
     add_tls_syntax(Base).
@@ -138,6 +141,7 @@ safe_syntax() ->
         external_url,
         ws_proto,
         headers,                % Not sure
+        tos,
         debug,
         http_inactivity_timeout,
         http_max_empty_lines,

--- a/src/nkpacket_transport.erl
+++ b/src/nkpacket_transport.erl
@@ -286,7 +286,7 @@ do_connect(#nkconn{protocol=Protocol, transp=Transp, ip=Ip, port=Port, opts=Opts
             ?DEBUG("base nkport: ~p", [lager:pr(BasePort2, ?MODULE)]),
             % Our listening host and meta must not be used for the new connection
             BaseMeta2 = maps:without([host, path], BaseMeta),
-            Opts2 = maps:merge(BaseMeta2, Opts),
+            Opts2 = maps:merge(Opts, BaseMeta2),
             ConnPort = BasePort2#nkport{
                 id = maps:get(id, Opts),
                 class = maps:get(class, Opts, none),

--- a/src/nkpacket_transport_tcp.erl
+++ b/src/nkpacket_transport_tcp.erl
@@ -356,7 +356,7 @@ connect_outbound(#nkport{remote_ip=Ip, remote_port=Port, opts=Opts, transp=tls}=
     list().
 
 outbound_opts(#nkport{opts=Opts}) ->
-    Opts1 = maps:to_list(maps:with([send_timeout, send_timeout_close], Opts)),
+    Opts1 = maps:to_list(maps:with([send_timeout, send_timeout_close, tos], Opts)),
     [
         binary,
         {active, false},
@@ -372,7 +372,7 @@ outbound_opts(#nkport{opts=Opts}) ->
     list().
 
 listen_opts(#nkport{transp=tcp, listen_ip=Ip, opts=Opts}) ->
-    Opts1 = maps:to_list(maps:with([send_timeout, send_timeout_close], Opts)),
+    Opts1 = maps:to_list(maps:with([send_timeout, send_timeout_close, tos], Opts)),
     [
         {packet, case Opts of #{tcp_packet:=Packet} -> Packet; _ -> raw end},
         binary,


### PR DESCRIPTION
To be able to define tos for connections the configuration parameter was added and used in tcp sip transport, so that listening and connecting over gen_tcp uses tos flag.

The pull request has also one fix, which enable to inherit options from already opened listener when a new connection is being established.